### PR TITLE
Set initial currency values to 0 for new users

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -117,15 +117,15 @@ const createMockClient = () => ({
                     ? [
                         {
                           id: "mock-user-123",
-                          xenocoins: 1000,
-                          cash: 100,
+                          xenocoins: 0,
+                          cash: 0,
                           username: "Demo User",
                           account_score: 0,
                           created_at: new Date().toISOString(),
                           last_login: new Date().toISOString(),
                           is_admin: false,
                           days_played: 1,
-                          total_xenocoins: 1000,
+                          total_xenocoins: 0,
                         },
                       ]
                     : [],
@@ -138,15 +138,15 @@ const createMockClient = () => ({
                     ? [
                         {
                           id: "mock-user-123",
-                          xenocoins: 1000,
-                          cash: 100,
+                          xenocoins: 0,
+                          cash: 0,
                           username: "Demo User",
                           account_score: 0,
                           created_at: new Date().toISOString(),
                           last_login: new Date().toISOString(),
                           is_admin: false,
                           days_played: 1,
-                          total_xenocoins: 1000,
+                          total_xenocoins: 0,
                         },
                       ]
                     : [],
@@ -159,8 +159,8 @@ const createMockClient = () => ({
                 table === "profiles"
                   ? {
                       id: "mock-user-123",
-                      xenocoins: 1000,
-                      cash: 100,
+                      xenocoins: 0,
+                      cash: 0,
                       username: "Demo User",
                     }
                   : null,
@@ -184,8 +184,8 @@ const createMockClient = () => ({
               table === "profiles"
                 ? {
                     id: "mock-user-123",
-                    xenocoins: 1000,
-                    cash: 100,
+                    xenocoins: 0,
+                    cash: 0,
                     username: "Demo User",
                   }
                 : null,

--- a/src/services/supabaseAuthService.ts
+++ b/src/services/supabaseAuthService.ts
@@ -137,7 +137,7 @@ export class SupabaseAuthService {
         language: this.detectLanguage(),
         accountScore: 0,
         daysPlayed: 0,
-        totalXenocoins: 1000,
+        totalXenocoins: 0,
         createdAt: new Date(),
         lastLogin: new Date(),
         preferences: this.getDefaultPreferences(),

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -21,11 +21,16 @@ interface GameStore extends GameState {
   setCurrentScreen: (screen: string) => void;
   setViewedUserId: (userId: string | null) => void;
 
-  // Egg hatching state
+  // Egg selection and hatching state
+  selectedEggForHatching: any | null;
+  isHatchingInProgress: boolean;
   hatchingEgg: {
     eggData: any;
     startTime: Date;
   } | null;
+  setSelectedEggForHatching: (eggData: any) => void;
+  clearSelectedEggForHatching: () => void;
+  setIsHatchingInProgress: (isHatching: boolean) => void;
   setHatchingEgg: (eggData: any) => void;
   clearHatchingEgg: () => void;
   getHatchingTimeRemaining: () => number;

--- a/supabase/migrations/20250626000000_fix_initial_currency.sql
+++ b/supabase/migrations/20250626000000_fix_initial_currency.sql
@@ -1,0 +1,88 @@
+/*
+  # Fix Initial Currency Values
+  
+  This migration fixes the initial currency values for new users to be 0 instead of 1000 Xenocoins and 10 Cash.
+  
+  1. Changes
+    - Update the handle_new_user function to set initial currencies to 0
+    - Update the default values in the profiles table schema for future consistency
+    
+  2. Security
+    - Function is marked as SECURITY DEFINER and owned by supabase_auth_admin
+*/
+
+-- Drop and recreate the handle_new_user function with correct initial values
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+DROP FUNCTION IF EXISTS public.handle_new_user();
+
+-- Recreate the function with 0 initial currency values
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.profiles (
+    id,
+    username,
+    phone,
+    is_admin,
+    language,
+    account_score,
+    days_played,
+    total_xenocoins,
+    xenocoins,
+    cash,
+    preferences,
+    created_at,
+    updated_at,
+    last_login
+  )
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'username', 'User'),
+    NEW.raw_user_meta_data->>'phone',
+    CASE 
+      WHEN LOWER(COALESCE(NEW.raw_user_meta_data->>'username', '')) = 'vitoca' THEN true
+      ELSE false
+    END,
+    COALESCE(NEW.raw_user_meta_data->>'language', 'en-US'),
+    0, -- account_score
+    0, -- days_played  
+    0, -- total_xenocoins
+    0, -- xenocoins starting amount (changed from 1000 to 0)
+    0, -- cash starting amount (changed from 10 to 0)
+    COALESCE(
+      NEW.raw_user_meta_data->>'preferences',
+      '{"notifications": true, "soundEffects": true, "musicVolume": 0.7, "language": "en-US", "theme": "light", "privacy": {"showOnline": true, "allowDuels": true, "allowTrades": true}}'
+    )::jsonb,
+    now(),
+    now(),
+    now()
+  );
+  
+  -- Add welcome notification
+  INSERT INTO public.notifications (user_id, type, title, message)
+  VALUES (
+    NEW.id,
+    'info',
+    'Bem-vindo aos Xenopets!',
+    'Sua aventura começa agora. Escolha seu primeiro ovo para começar!'
+  );
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Recreate the trigger
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Update the default values in the profiles table for consistency
+-- (This won't affect existing users, only new users if the trigger fails)
+ALTER TABLE public.profiles 
+  ALTER COLUMN xenocoins SET DEFAULT 0,
+  ALTER COLUMN cash SET DEFAULT 0;
+
+-- Grant necessary permissions
+GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
+GRANT ALL ON public.profiles TO supabase_auth_admin;
+GRANT ALL ON public.notifications TO supabase_auth_admin;


### PR DESCRIPTION
Updates initial currency values for new users from 1000 xenocoins and 100 cash to 0 for both currencies.

Changes made:
- Updated mock client data in supabase.ts to use 0 xenocoins and 0 cash
- Modified SupabaseAuthService to set totalXenocoins to 0 for new users
- Added egg selection and hatching state properties to gameStore
- Created database migration to update handle_new_user function with 0 initial currency values
- Updated profiles table default values to 0 for xenocoins and cash columns

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b3240acc3a9f49b6a7d3436db3e06be2/mystic-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b3240acc3a9f49b6a7d3436db3e06be2</projectId>-->
<!--<branchName>mystic-hub</branchName>-->